### PR TITLE
redux of step 15, other minor changes

### DIFF
--- a/R/05_mc_hmd.R
+++ b/R/05_mc_hmd.R
@@ -74,7 +74,10 @@ external_ref_quarter <- external_ref %>%
                            m = 1, 
                            k = 11, 
                            age_interval_out = 0.25)) %>%
-  ungroup()
+  ungroup() |> 
+  mutate(mx = c(mx))
+
+write_csv(external_ref_quarter,file = "Data/external_ref_point.csv")
 
 external_ref |> 
   mutate(mx = deaths / exposure) |> 

--- a/R/15_e50_check_adj_unadj.R
+++ b/R/15_e50_check_adj_unadj.R
@@ -1,172 +1,208 @@
 # males line 605
 # females 295
-# source("R/00_dependencies.R")
-# source("R/01_functions_extra.R")
-# # which replicate is the median e50?
-# probs <- read_csv("Data/model2/probs.csv.gz")
-# # # expectancies, age 50
-# e50 <- calc_exs(probs = probs,
-#                 from_age = 50,
-#                 age_interval = 0.25,
-#                 init = c(`1` = 1, `2` = 0),
-#                 init_method = "init",
-#                 from_col = "from",
-#                 to_col = "to",
-#                 age_col = "age",
-#                 p_col = "p",
-#                 group_cols = c("replicate", "female", "year"),
-#                 trans_col = "transition") |>
-#   ungroup()
+source("R/00_dependencies.R")
+source("R/01_functions.R")
+source("R/02_prepare_hrs.R")
+source("R/01_functions.R")
+source("R/01_functions_extra.R")
 
+hrs_to_fit_prepped <- 
+  hrs_to_fit |>
+  mutate( year = floor(obs_date)) |>
+  select(hhidpn, female, education,
+         pwt = wtcrnh, age, hypertension:stroke,
+         state_msm, ever_dementia, obstype,
+         year) |> 
+  filter(year > 2003)
 
-# females 295
-# males 605
-df <- e50 %>%
-  group_by(year, female) %>% 
-  # filter(year == 2019) %>% 
-  mutate(LE = DFLE + DLE,
-         res = LE - median(LE)) %>% 
-  filter(res == min(abs(res))) %>% 
-  select(1, 2, 3)
-
-# real tibble of replicates and corresponding values
-df <- tribble(
-  ~replicate, ~female, ~year,
-  155, 1, 2010,
-  156, 0, 2006,
-  183, 0, 2007,
-  208, 1, 2004,
-  256, 0, 2015,
-  283, 1, 2005,
-  295, 1, 2019,
-  344, 0, 2010,
-  369, 1, 2013,
-  381, 0, 2011,
-  415, 1, 2015,
-  550, 1, 2011,
-  596, 1, 2006,
-  605, 0, 2019,
-  618, 0, 2009,
-  680, 1, 2017,
-  753, 0, 2014,
-  767, 0, 2017,
-  768, 0, 2004,
-  779, 0, 2012,
-  815, 1, 2008,
-  826, 1, 2014,
-  869, 1, 2007,
-  903, 1, 2009,
-  960, 0, 2013,
-  982, 0, 2018
+Q_mod2 <- rbind(
+  c(-0.2,  0.1, 0.1),
+  c( 0,   -0.01, 0.1),
+  c( 0,    0,   0)
 )
 
+haz_unadj <- hrs_to_fit_prepped |>
+  fit_msm(
+    strat_vars    = c("female"),
+    covariate_var = c("age", "year"),
+    age_from_to   = c(50, 100),
+    age_int       = 0.25,
+    spline_df     = NULL,
+    spline_type   = "ns",
+    Q             = Q_mod2
+  ) |>
+  dplyr::mutate(replicate = 1L, .before = 1)
 
-prev          <- read_csv("Data/model2/prev_replicates.csv.gz",      show_col_types = FALSE)
-hazards_unadj <- read_csv("Data/model2/unadj_haz_replicates.csv.gz", show_col_types = FALSE)
-hazards_adj   <- read_csv("Data/model2/adj_haz_replicates.csv.gz",   show_col_types = FALSE)
+prev <- hrs_to_fit_prepped |>
+  fit_prev(
+    strat_vars      = c("female"),
+    covariate_var   = c("age", "year"),
+    age_from_to     = c(50, 100),
+    age_int         = 0.25,
+    condition_state = 2L,
+    spline_df       = NULL,
+    spline_type     = "ns",
+    state_var       = "state_msm",
+    weight_col      = "pwt",
+    id_col          = "hhidpn",
+    exclude_state   = 3L
+  ) |>
+  dplyr::mutate(replicate = 1L, .before = 1)
 
-prev1 <- prev %>% 
-  semi_join(
-    df,
-    by = c("replicate", "female", "year")
-  )  
-  # filter(female == 0 & replicate == 605 |
-  #        female == 1 & replicate == 295,
-  #        year == 2019) %>% 
-  # select(-year)
+probs_unadj <-
+  haz_unadj |> 
+  hazards_to_discrete(
+    age_interval = 0.25,
+    id_cols      = c("age", "female", "year"),
+    n_cores      = 10,
+    parallel     = "mclapply")
 
-unadj <- hazards_unadj %>% 
-  semi_join(
-    df,
-    by = c("replicate", "female", "year")
-  )  %>% 
-  filter(
-    # female == 0 & replicate == 605 |
-    #   female == 1 & replicate == 295,
-    #      year == 2019,
-         to > from) |> # create c from and to columns
-  mutate(from = ifelse(from == 1, "H", "U"),
-         to   = case_when(
-           to == 1 ~ "H",
-           to == 2 ~ "U",
-           to == 3 ~ "D"
-         )) %>% 
-  mutate(transition = paste0(from, "_", to)) %>%
-  select(-from, -to) %>%
-  pivot_wider(names_from  = transition, 
-              values_from = haz) %>%
-  select(-H_U) %>%
-  left_join(
-    prev,
-    by = join_by(replicate, age, female, year)
-  ) %>% 
+e50_unadj <-
+  probs_unadj |> 
+  mutate(transition = paste(from,to,sep="-")) |> 
+  calc_exs(from_age = 50, 
+           age_interval = 0.25, 
+           init = c(`1` = 1, `2` = 0) ,
+           init_method = "init", 
+           from_col = "from", 
+           to_col = "to", 
+           age_col = "age", 
+           p_col = "p", 
+           group_cols = c("female", "year"), 
+           trans_col = "transition") |> 
+  mutate(LE = DFLE + DLE,
+         adjusted = FALSE)
+
+e50_unadj_lt <-
+  haz_unadj |> 
+  filter(to == 3,
+         from < 3) |> 
+  mutate(transition = if_else(from == 1,"HD","UD")) |> 
+  select(-from,-to,-replicate) |> 
+  pivot_wider(names_from = transition, values_from = haz) |> 
+  left_join(prev |> select(-replicate),
+            by = join_by(female, age, year)) |> 
+  mutate(mx = HD * (1 - prevalence) + UD * prevalence) |> 
+  group_by(female, year) |> 
+  mutate(ax = .125,
+         qx = (.25 * mx) / (1 + (.25 - ax) * mx),
+         lx = c(1,cumprod(1-qx[-n()])),
+         dx = lx * qx,
+         Lx = lx * .25 - (1 - ax) * dx) |> 
+  summarize(LE = sum(Lx))
+
+external_mort <- 
+  read_csv("Data/external_ref_point.csv",show_col_types = FALSE)
+
+haz_adj <-
+  haz_unadj |> 
+  mutate(female = as.integer(female)-1) |> 
+  mutate(transition = paste0("h",from,"_",to)) |> 
+  select(-from,-to) |> 
+  pivot_wider(names_from = transition, values_from = haz) |> 
+  left_join(prev |> select(-replicate) |> mutate(female = as.integer(female)-1), 
+            by = join_by(age, female, year)) |> 
+  left_join(external_mort, 
+            by = join_by(age, female, year)) |> 
   mutate(
-    mx = (1 - prevalence) * H_D + prevalence  * U_D,
-    female = ifelse(female == 1, "Women", "Men")) %>%
-  arrange(replicate, female, year, age) %>% 
-  select(-replicate) %>% 
-  mutate(Hazards = "Before adjustment")%>% 
-  select(-c(H_D, U_D, prevalence))
+    Rx = h2_3 / h1_3,
+    h1_3 = mx / (1 - prevalence + prevalence * Rx),
+    h2_3 = h1_3 * Rx,
+    h1_1 = -(h1_2 + h1_3),
+    h2_2 = -(h2_1 + h2_3)) |> 
+  select(replicate, age, female, year, starts_with("h")) |> 
+  pivot_longer(starts_with("h"), 
+               names_to = "transition", 
+               values_to = "haz") |> 
+  mutate(transition = substr(transition,2,4)) |> 
+  separate_wider_delim(transition,names=c("from","to"), delim="_") |> 
+  mutate(from = as.integer(from),
+         to = as.integer(to)) |> 
+  filter(from < 3)
 
-# ABSOLUTELY SAME CODE
-adj <- hazards_adj %>% 
-  semi_join(
-    df,
-    by = c("replicate", "female", "year")
-  )  %>%
-  filter(
-    # female == 0 & replicate == 605 |
-    #   female == 1 & replicate == 295,
-    #      year == 2019,
-    to > from) |> # create c from and to columns
-  mutate(from = ifelse(from == 1, "H", "U"),
-         to   = case_when(
-           to == 1 ~ "H",
-           to == 2 ~ "U",
-           to == 3 ~ "D"
-         )) %>% 
-  mutate(transition = paste0(from, "_", to)) %>%
-  select(-from, -to) %>%
-  pivot_wider(names_from  = transition, 
-              values_from = haz) %>%
-  select(-H_U) %>%
-  left_join(
-    prev,
-    by = join_by(replicate, age, female, year)
-  ) %>% 
-  mutate(
-    mx = (1 - prevalence) * H_D + prevalence  * U_D,
-    female = ifelse(female == 1, "Women", "Men")) %>%
-  arrange(replicate, female, year, age) %>% 
-  select(-replicate) %>% 
-  mutate(Hazards = "After adjustment")%>% 
-  select(-c(H_D, U_D, prevalence))
+haz_compare <-
+  haz_adj |> 
+  mutate(adjusted = TRUE) |> 
+  bind_rows(haz_unadj |> mutate(female = as.integer(female)-1,adjusted = FALSE))
 
-# ------------------------------------------------------------------- #
-# e50
-z <- adj %>% 
-  full_join(unadj) %>%
-  group_by(Hazards, female, year) %>% 
-  summarise(
-    # I assume quarters     
-    e50 = sum(exp(-cumsum(mx * 0.25))) * 0.25,
-    .groups = "drop"
-  )
+# in 2005, the adjustment increases HD and UD, but in 2019 it decreases them
+# I didn't expect HRS to overestimate mortality ever..
+haz_compare |> 
+  filter(to > from, year %in% c(2005,2019)) |> 
+  ggplot(aes(x = age, y = haz, color = interaction(from, to), linetype = adjusted)) +
+  geom_line() + 
+  facet_wrap(year~female) +
+  scale_y_log10() +
+  geom_line(data = external_mort |> filter(year %in% c(2005,2019)) |> rename(haz=mx) |> mutate(adjusted = FALSE), color = "black")
 
-# Something wrong
-z %>% 
-  ggplot(
-  aes(
-    x = year,
-    y = e50,
-    color = female,
-    linetype = Hazards,
-    group = interaction(female, Hazards)
-  )
-) +
-  geom_line(
-    linewidth = 1
-  ) +
-  geom_point(
-    size = 2
-  )
+probs_adj <-
+  haz_adj |> 
+  arrange(year,female,age, from,to) |> 
+  hazards_to_discrete(
+    age_interval = 0.25,
+    id_cols      = c("age", "female", "year"),
+    n_cores      = 10,
+    parallel     = "mclapply")
+
+e50_adj <-
+  probs_adj |> 
+  mutate(transition = paste(from,to,sep="-")) |> 
+  calc_exs(from_age = 50, 
+           age_interval = 0.25, 
+           init = c(`1` = 1, `2` = 0) ,
+           init_method = "init", 
+           from_col = "from", 
+           to_col = "to", 
+           age_col = "age", 
+           p_col = "p", 
+           group_cols = c("female", "year"), 
+           trans_col = "transition") |> 
+  mutate(LE = DFLE + DLE,
+         adjusted = TRUE)
+
+e50_adj_lt <-
+  haz_adj |> 
+  filter(to == 3,
+         from < 3) |> 
+  mutate(transition = if_else(from == 1,"HD","UD")) |> 
+  select(-from,-to,-replicate) |> 
+  pivot_wider(names_from = transition, values_from = haz) |> 
+  left_join(prev |> select(-replicate) |> mutate(female = as.integer(female) - 1),
+            by = join_by(female, age, year)) |> 
+  mutate(mx = HD * (1 - prevalence) + UD * prevalence) |> 
+  group_by(female, year) |> 
+  mutate(ax = .125,
+         qx = (.25 * mx) / (1 + (.25 - ax) * mx),
+         lx = c(1,cumprod(1-qx[-n()])),
+         dx = lx * qx,
+         Lx = lx * .25 - (1 - ax) * dx) |> 
+  summarize(LE = sum(Lx), .groups= "drop") |> 
+  mutate(method = "lt",
+         adjusted = TRUE)
+
+e50 <-
+  bind_rows(e50_adj|> 
+              mutate(method = "mslt",
+                     adjusted = TRUE), 
+            e50_unadj |>  
+              mutate(method = "mslt",
+                     adjusted = FALSE,
+                     female = as.integer(female)-1),
+            e50_adj_lt|> 
+              mutate(method = "lt",
+                     adjusted = TRUE), 
+            e50_unadj_lt |>  
+              mutate(method = "lt",
+                     adjusted = FALSE,
+                     female = as.integer(female)-1)) 
+  
+
+# It seems to be the case that 
+e50 |> 
+  ggplot(aes(x= year, 
+             y = LE, 
+             color = adjusted, 
+             linetype = method)) +
+  facet_wrap(~female) +
+  geom_point() + 
+  geom_line()


### PR DESCRIPTION
have a look at the new step 15 check.
It is the case that our unadjusted estimates of mortality in the first years are mortality underestimates, meaning that the adjustment raises mortality. But in more recent years HRS gives too-high mortality estimates, so HMD brings them down. I wonder if the person weights we use somehow oversample respondents in nursing homes? Or I wonder if our code in prepare_hrs.R is assigning death dates and death ages properly? iwstat = 5 i think means dead at time of wave, and we use it. We also use raddate. I'm not sure if it's ever the case that raddate is missing if iwstat is 5, or if raddate is given but iwstat is not 5 when it should be. Those lines should be scrutinized to make sure we're not inventing deaths where we shouldn't. After examining step 15, please do a thorough audit of step 02 for this detail. This means doing piecewise step-throughs, examining the use of raddate (death_date), how it translate to the msm state, how it uses iwstat information, and so on. Sorry, but the reason why I think this audit is required now is due to the size of the adjustment and the fact that it flips its sign, going from the standard udnerstimates of mortality (Expected) to the unexpected overestimate of mortality. A secondary diagnostic would be to estimate an all-cause mortality-only model using msm with spline_df = 2, and see what we get.